### PR TITLE
Fix a bug with quota in transactions.

### DIFF
--- a/server/quota.ml
+++ b/server/quota.ml
@@ -107,4 +107,10 @@ let incr quota id =
 let union quota diff =
 	Hashtbl.iter (fun id nb -> set quota id (get quota id + nb)) diff.cur
 
+let merge orig_quota mod_quota dest_quota =
+  Hashtbl.iter (fun id nb ->
+    let diff = nb - (get orig_quota id) in
+    if diff <> 0 then
+      set dest_quota id ((get dest_quota id) + diff)) mod_quota.cur
+
 

--- a/server/quota.mli
+++ b/server/quota.mli
@@ -81,6 +81,9 @@ val copy: t -> t
 val union: t -> t -> unit
 (** [union a b] adds all entries from [b] to [a] *)
 
+val merge: t -> t -> t -> unit
+(** [union a b] adds all entries from [b] to [a] *)
+
 val check: t -> int -> int -> unit
 (** [check t domid size]
 	throws Data_too_big if [size] is too large

--- a/server/store.mli
+++ b/server/store.mli
@@ -137,6 +137,6 @@ val read: t -> Perms.t -> Path.t -> string
 val getperms: t -> Perms.t -> Path.t -> Xs_protocol.ACL.t
 
 
-val set_node: t -> Path.t -> Node.t -> unit
+val set_node: t -> Path.t -> Node.t -> Quota.t -> Quota.t -> unit
 
 val mark_symbols: t -> unit

--- a/server/transaction.ml
+++ b/server/transaction.ml
@@ -67,6 +67,7 @@ type ty = No | Full of (int32 * Store.Node.t * Store.t)
 type t = {
 	ty: ty;
 	store: Store.t;
+	quota: Quota.t;
 	mutable paths: (Xs_protocol.Op.t * Store.Name.t) list;
 	mutable operations: (Xs_protocol.Request.payload * Xs_protocol.Response.payload) list;
 	mutable read_lowpath: Store.Path.t option;
@@ -78,6 +79,7 @@ let make id store =
 	{
 		ty = ty;
 		store = if id = none then store else Store.copy store;
+		quota = Quota.copy  store.Store.quota;
 		paths = [];
 		operations = [];
 		read_lowpath = None;
@@ -157,7 +159,7 @@ let commit ~con t =
 
 					(* it has to be in the store, otherwise it means bugs
 					   in the lowpath registration. we don't need to handle none. *)
-					maybe (fun n -> Store.set_node cstore p n) n;
+					maybe (fun n -> Store.set_node cstore p n t.quota store.Store.quota) n;
 					Logging.write_coalesce ~tid:(get_id t) ~con (Store.Path.to_string p);
 				) t.write_lowpath;
 				maybe (fun p ->


### PR DESCRIPTION
CA-100569: Perform a 3-way merge a the quota after a transaction.

At the beginning of a transaction, the quotas from the global store are duplicated
and modified by the transaction. If during the transaction, an action associated
to no transaction were concurrently executed, the quotas of the global store
were updated, but the change from the transaction would be unaccounted in the
quota.
This commit fix this problem by keeping another copy of the quota at the
beginning of the transaction, and performing a 3-way merge between the quotas
from the transaction and the "original" copy of the quota onto the quotas
of the global store.
