### PR TITLE
CA-125868: Return the task for a wait asynchronously

### DIFF
--- a/client_unix/xs_client_unix.ml
+++ b/client_unix/xs_client_unix.ml
@@ -375,12 +375,15 @@ module Client = functor(IO: IO with type 'a t = 'a) -> struct
         loop ()
       end
     in
-    finally loop
-      (fun () ->
-        let current_paths = Xs_handle.get_watched_paths h in
-        List.iter (fun p -> unwatch h p token) (elements current_paths);
-        with_mutex client.m (fun () -> Hashtbl.remove client.watchevents token);
-      );
+    let (_: Thread.t) =
+      Thread.create (fun () ->
+        finally loop (fun () ->
+          let current_paths = Xs_handle.get_watched_paths h in
+          List.iter (fun p -> unwatch h p token) (elements current_paths);
+          with_mutex client.m (fun () -> Hashtbl.remove client.watchevents token);
+        )
+      ) ()
+    in
     t
 
   let rec transaction client f =


### PR DESCRIPTION
Xenopsd uses this task to schedule a timeout on a watch. We need to make
sure this call doesn't block before returning the task.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
