### PR TITLE
CA-195461: increase limit of maximum incoming watches to xenstore

### DIFF
--- a/client_unix/xs_client_unix.ml
+++ b/client_unix/xs_client_unix.ml
@@ -198,7 +198,7 @@ module Client = functor(IO: IO with type 'a t = 'a) -> struct
   let enqueue_watch t event =
     with_mutex t.incoming_watches_m
       (fun () ->
-	if Queue.length t.incoming_watches = 1024
+	if Queue.length t.incoming_watches = 65536
 	then t.queue_overflowed := true
 	else Queue.push event t.incoming_watches;
 	Condition.signal t.incoming_watches_c


### PR DESCRIPTION
from 1024 to 65536, to cope with the increase of maximum VBDs/VM
limit from 16 to 255.

Each VBD will create around 5 watches in xenstore. With the current
limit of 1024 incoming watches, a single VM with more than 200 VBDs
would cause the queue_overflowed flag to be set, and the watch
event engine in the ocaml xenstore client would freeze.
